### PR TITLE
Add `BaseActionGenerator`.

### DIFF
--- a/src/action_generator.rs
+++ b/src/action_generator.rs
@@ -1,0 +1,37 @@
+use std::sync::{RwLock, Weak};
+
+use super::action::Action;
+use super::thing::Thing;
+
+/// Generator for new actions, based on name.
+pub trait ActionGenerator: Send + Sync {
+    /// Generate a new action, if possible.
+    ///
+    /// # Arguments
+    ///
+    /// * `thing` - thing associated with this action
+    /// * `name` - name of the requested action
+    /// * `input` - input for the action
+    fn generate(
+        &self,
+        thing: Weak<RwLock<Box<dyn Thing>>>,
+        name: String,
+        input: Option<&serde_json::Value>,
+    ) -> Option<Box<dyn Action>>;
+}
+
+/// Basic action generator implementation.
+///
+/// This always returns `None` and can be used when no actions are needed.
+pub struct BaseActionGenerator;
+
+impl ActionGenerator for BaseActionGenerator {
+    fn generate(
+        &self,
+        _thing: Weak<RwLock<Box<dyn Thing>>>,
+        _name: String,
+        _input: Option<&serde_json::Value>,
+    ) -> Option<Box<dyn Action>> {
+        None
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,9 @@ extern crate std;
 /// Action trait and base implementation.
 pub mod action;
 
+/// ActionGenerator trait and base implementation.
+pub mod action_generator;
+
 /// Event trait and base implementation.
 pub mod event;
 
@@ -23,6 +26,7 @@ pub mod thing;
 pub mod utils;
 
 pub use action::{Action, BaseAction};
+pub use action_generator::BaseActionGenerator;
 pub use event::{BaseEvent, Event};
 pub use property::{BaseProperty, Property};
 pub use server::{ThingsType, WebThingServer};

--- a/src/server.rs
+++ b/src/server.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use uuid::Uuid;
 
 use super::action::Action;
+pub use super::action_generator::ActionGenerator;
 use super::thing::Thing;
 use super::utils::get_addresses;
 
@@ -34,23 +35,6 @@ pub enum ThingsType {
     Multiple(Vec<Arc<RwLock<Box<dyn Thing>>>>, String),
     /// Set when there is only one thing
     Single(Arc<RwLock<Box<dyn Thing>>>),
-}
-
-/// Generator for new actions, based on name.
-pub trait ActionGenerator: Send + Sync {
-    /// Generate a new action, if possible.
-    ///
-    /// # Arguments
-    ///
-    /// * `thing` - thing associated with this action
-    /// * `name` - name of the requested action
-    /// * `input` - input for the action
-    fn generate(
-        &self,
-        thing: Weak<RwLock<Box<dyn Thing>>>,
-        name: String,
-        input: Option<&serde_json::Value>,
-    ) -> Option<Box<dyn Action>>;
 }
 
 /// Shared app state, used by server threads.


### PR DESCRIPTION
Reduce boilerplate when creating a server which doesn't need actions.
